### PR TITLE
\sa tags for vehicle variables

### DIFF
--- a/Character.h
+++ b/Character.h
@@ -435,6 +435,9 @@ RPG::hero->move(moves.c_str(), moves.length());
 	static RPG::Hero *&hero = (**reinterpret_cast<RPG::Hero ***>(0x4CDE54));
 
 	/*! \brief Used for the vehicles as subtype of characters
+		\sa RPG::vehicleSkiff
+		\sa RPG::vehicleShip
+		\sa RPG::vehicleAirship
 		\sa RPG::hero
 	*/
 	class Vehicle : public Character {


### PR DESCRIPTION
Added \sa tags for RPG::vehicleSkiff, RPG::vehicleShip, and RPG::vehicleAirship to doxygen for class Vehicle.

May want to remove \sa tag for RPG::hero as well, I wouldn't be surprised if the doxygen was copy-pasted from elsewhere with the intent of modifying that but it was forgotten.